### PR TITLE
[CLS-11150] feature: Add a filter to retrieve only the assume role policy document

### DIFF
--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -3497,6 +3497,31 @@ class IamRoleInlinePolicies(Filter):
         return matched
 
 
+@Role.filter_registry.register('assume-role-policy-id-only')
+class AssumeRolePolicyIdFilter(Filter):
+    schema = type_schema('assume-role-policy-id-only', value={'type': 'string'})
+    permissions = ('iam:GetRole',)
+
+    def process(self, resources, event=None):
+        value = self.data.get('value', True)
+        res = []
+        for r in resources:
+            self.generate_assume_role_policy_id(r, value)
+            res.append(r)
+        return res
+
+    def generate_assume_role_policy_id(self,r, value):
+        assume_role_policy_doc = r['AssumeRolePolicyDocument']
+        if bool(assume_role_policy_doc):
+            if value.lower() == 'n':
+                return
+            r['AssumeRolePolicyName'] = r['RoleName'] + '-' + 'AssumeRolePolicy'
+            if value.lower() == 'y':
+                del r['AssumeRolePolicyDocument']
+            if value.lower() == 'both':
+                return
+
+
 # ############### S1 Role Filters- END ##################
 
 

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -3522,6 +3522,25 @@ class AssumeRolePolicyIdFilter(Filter):
                 return
 
 
+@Role.filter_registry.register('assume-role-policy-document-only')
+class AssumeRolePolicyIdFilter(Filter):
+    schema = type_schema('assume-role-policy-document-only')
+    permissions = ('iam:GetRole',)
+
+    def process(self, resources, event=None):
+        res = []
+        for r in resources:
+            assume_role_policy_doc = self.get_assume_role_policy_document(r)
+            res.append(assume_role_policy_doc)
+        return res
+
+    def get_assume_role_policy_document(self, r):
+        assume_role_policy_doc = r['AssumeRolePolicyDocument']
+        assume_role_policy_doc['AssumeRolePolicyName'] = r['RoleName'] + '-' + 'AssumeRolePolicy'
+        assume_role_policy_doc['AssumeRolePolicyId'] = r['RoleName'] + '-' + 'AssumeRolePolicy'
+        return assume_role_policy_doc
+
+
 # ############### S1 Role Filters- END ##################
 
 


### PR DESCRIPTION
1. Add a filter to retrieve only the assume role policy document